### PR TITLE
Correct regular expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ async function handleRequest(request) {
   else if(password.match(/[\u0370-\u03ff\u1f00-\u1fff]/) === null) {
     badPasswordMessage = 'Password must contain at least 1 Greek character';
   }
-  else if(password.match(/Peter|Lois|Chris|Meg|Brian|Stewie/) === null) {
+  else if(password.match(/Peter|Lois|Chris|Meg|Brian|Stewie/) !== null) {
     badPasswordMessage = 'Password must not contain any primary Griffin family character';
   }
   else if(password.match(/:‑\)|:\)|:\-\]|:\]|:>|:\-\}|:\}|:o\)\)|:\^\)|=\]|=\)|:\]|:\->|:>|8\-\)|:\-\}|:\}|:o\)|:\^\)|=\]|=\)|:‑D|:D|B\^D|:‑\(|:\(|:‑<|:<|:‑\[|:\[|:\-\|\||>:\[|:\{|:\(|;\(|:\'‑\(|:\'\(|:=\(|:\'‑\)|:\'\)|:"D|:‑O|:O|:‑o|:o|:\-0|>:O|>:3|;‑\)|;\)|;‑\]|;\^\)|:‑P|:\-\/|:\/|:‑\.|>:|>:\/|:|:‑\||:\||>:‑\)|>:\)|\}:‑\)|>;‑\)|>;\)|>:3|\|;‑\)|:‑J|<:‑\||~:>/) === null) {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ async function handleRequest(request) {
   let password = searchParams.get('password')
   let badPasswordMessage = 'Password looks fine, but you\'ll never see this message when we\'re done here 🙂';
 
+  // The code below makes extensive use of JavaScript regular expressions.
+  // See the documentation here:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
+
   if(password === null) {
     badPasswordMessage = 'No password was provided';
   }

--- a/index.js
+++ b/index.js
@@ -16,43 +16,43 @@ async function handleRequest(request) {
   else if(password.match(/\d+/g) === null) {
     badPasswordMessage = 'Password must contain at least 1 number';
   }
-  else if(password.match('[A-Z]') === null) {
+  else if(password.match(/[A-Z]/) === null) {
     badPasswordMessage = 'Password must contain at least 1 uppercase character';
   }
-  else if(password.match('[a-z]') === null) {
+  else if(password.match(/[a-z]/) === null) {
     badPasswordMessage = 'Password must contain at least 1 lowercase character';
   }
-  else if(password.match('/Homer|Marge|Bart|Lisa|Maggie/g') === null) {
+  else if(password.match(/Homer|Marge|Bart|Lisa|Maggie/) === null) {
     badPasswordMessage = 'Password must contain at least 1 primary Simpsons family character';
   }
   else if(password.match(/[ÅåÄäÖöÆæØø]/g) === null) {
     badPasswordMessage = 'Password must contain at least 1 Nordic character';
   }
-  else if(password.match(/[\u0370-\u03ff\u1f00-\u1fff]/g) === null) {
+  else if(password.match(/[\u0370-\u03ff\u1f00-\u1fff]/) === null) {
     badPasswordMessage = 'Password must contain at least 1 Greek character';
   }
-  else if(password.match('/Peter|Lois|Chris|Meg|Brian|Stewie/g') !== null) {
+  else if(password.match(/Peter|Lois|Chris|Meg|Brian|Stewie/) === null) {
     badPasswordMessage = 'Password must not contain any primary Griffin family character';
   }
-  else if(password.match('/:‑\)|:\)|:\-\]|:\]|:>|:\-\}|:\}|:o\)\)|:\^\)|=\]|=\)|:\]|:\->|:>|8\-\)|:\-\}|:\}|:o\)|:\^\)|=\]|=\)|:‑D|:D|B\^D|:‑\(|:\(|:‑<|:<|:‑\[|:\[|:\-\|\||>:\[|:\{|:\(|;\(|:\'‑\(|:\'\(|:=\(|:\'‑\)|:\'\)|:"D|:‑O|:O|:‑o|:o|:\-0|>:O|>:3|;‑\)|;\)|;‑\]|;\^\)|:‑P|:\-\/|:\/|:‑\.|>:|>:\/|:|:‑\||:\||>:‑\)|>:\)|\}:‑\)|>;‑\)|>;\)|>:3|\|;‑\)|:‑J|<:‑\||~:>/g') === null) {
+  else if(password.match(/:‑\)|:\)|:\-\]|:\]|:>|:\-\}|:\}|:o\)\)|:\^\)|=\]|=\)|:\]|:\->|:>|8\-\)|:\-\}|:\}|:o\)|:\^\)|=\]|=\)|:‑D|:D|B\^D|:‑\(|:\(|:‑<|:<|:‑\[|:\[|:\-\|\||>:\[|:\{|:\(|;\(|:\'‑\(|:\'\(|:=\(|:\'‑\)|:\'\)|:"D|:‑O|:O|:‑o|:o|:\-0|>:O|>:3|;‑\)|;\)|;‑\]|;\^\)|:‑P|:\-\/|:\/|:‑\.|>:|>:\/|:|:‑\||:\||>:‑\)|>:\)|\}:‑\)|>;‑\)|>;\)|>:3|\|;‑\)|:‑J|<:‑\||~:>/) === null) {
     badPasswordMessage = 'Password must contain at least one emoticon';
   }
   else if([].concat(password.match(/[0-9]/g)).map(Number).reduce( (a, b) => a + b) % 3 !== 0) {
     badPasswordMessage = 'Password when stripped of non-numeric characters must be a number divisible by 3';
   }
-  else if(password.match('\d{5}(-\d{4})?') === null) {
+  else if(password.match(/\d{5}(-\d{4})?/) === null) {
     badPasswordMessage = 'Password must contain a United States zip code';
   }
-  else if(password.match(/[ÄÜÖẞ]/g) === null) {
+  else if(password.match(/[ÄÜÖẞ]/) === null) {
     badPasswordMessage = 'Password must contain at leat one upper case German Umlaut';
   }
-  else if(password.match('dog$') === null) {
+  else if(password.match(/dog$/) === null) {
     badPasswordMessage = 'Password must end with dog';
   }
-  else if(password.match('^cat') === null) {
+  else if(password.match(/^cat/) === null) {
     badPasswordMessage = 'Password must start with cat';
   }
-  else if (password.match('/Luna|Deimos|Phobos|Amalthea|Callisto|Europa|Ganymede|Io|Dione|Enceladus|Hyperion|Iapetus|Mimas|Phoebe|Rhea|Tethys|Titan|Ariel|Miranda|Oberon|Titania|Umbriel|Nereid|Triton|Charon|Himalia|Carme|Ananke|Adrastea|Elara|Adrastea|Elara|Epimetheus|Callirrhoe|Kalyke|Thebe|Methone|Kiviuq|Ijiraq|Paaliaq|Albiorix|Erriapus|Pallene|Polydeuces|Bestla|Daphnis|Despina|Puck|Carpo|Pasiphae|Themisto|Cyllene|Isonoe|Harpalyke|Hermippe|Iocaste|Chaldene|Euporie/g') === null) {
+  else if (password.match(/Luna|Deimos|Phobos|Amalthea|Callisto|Europa|Ganymede|Io|Dione|Enceladus|Hyperion|Iapetus|Mimas|Phoebe|Rhea|Tethys|Titan|Ariel|Miranda|Oberon|Titania|Umbriel|Nereid|Triton|Charon|Himalia|Carme|Ananke|Adrastea|Elara|Adrastea|Elara|Epimetheus|Callirrhoe|Kalyke|Thebe|Methone|Kiviuq|Ijiraq|Paaliaq|Albiorix|Erriapus|Pallene|Polydeuces|Bestla|Daphnis|Despina|Puck|Carpo|Pasiphae|Themisto|Cyllene|Isonoe|Harpalyke|Hermippe|Iocaste|Chaldene|Euporie/) === null) {
     badPasswordMessage = 'Password must contain at least one named solarian planetary satellite';
 
   }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ async function handleRequest(request) {
     },
     {
       passwordIsInvalid: password =>
-        password.match('/Peter|Lois|Chris|Meg|Brian|Stewie/g') !== null,
+        password.match(/Peter|Lois|Chris|Meg|Brian|Stewie/) !== null,
       message: 'Password must not contain any primary Griffin family character',
     },
     {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function handleRequest(request) {
 
   // The code below makes extensive use of JavaScript regular expressions.
   // See the documentation here:
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
   if(password === null) {
     badPasswordMessage = 'No password was provided';

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ async function handleRequest(request) {
   else if(password.length < 8) {
     badPasswordMessage = 'Password must be at least 8 characters long';
   }
-  else if(password.match(/\d+/g) === null) {
+  else if(password.match(/\d+/) === null) {
     badPasswordMessage = 'Password must contain at least 1 number';
   }
   else if(password.match(/[A-Z]/) === null) {
@@ -25,7 +25,7 @@ async function handleRequest(request) {
   else if(password.match(/Homer|Marge|Bart|Lisa|Maggie/) === null) {
     badPasswordMessage = 'Password must contain at least 1 primary Simpsons family character';
   }
-  else if(password.match(/[ÅåÄäÖöÆæØø]/g) === null) {
+  else if(password.match(/[ÅåÄäÖöÆæØø]/) === null) {
     badPasswordMessage = 'Password must contain at least 1 Nordic character';
   }
   else if(password.match(/[\u0370-\u03ff\u1f00-\u1fff]/) === null) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ async function handleRequest(request) {
       message: 'Password must not contain any primary Griffin family character',
     },
     {
-      // TODO: Regex is broken, disabled for now.
       passwordIsInvalid: password => password.match(
         /:‑)|:)|:-]|:]|:>|:-}|:}|:o))|:^)|=]|=)|:]|:->|:>|8-)|:-}|:}|:o)|:^)|=]|=)|:‑D|:D|B^D|:‑(|:(|:‑<|:<|:‑[|:[|:-|||>:[|:{|:(|;(|:'‑(|:'(|:=(|:'‑)|:')|:\"D|:‑O|:O|:‑o|:o|:-0|>:O|>:3|;‑)|;)|;‑]|;^)|:‑P|:-/|:/|:‑.|>:|>:/|:|:‑||:||>:‑)|>:)|}:‑)|>;‑)|>;)|>:3||;‑)|:‑J|<:‑||~:>/,
       ) === null,


### PR DESCRIPTION
Several of them used strings instead of JS regular expressions. This is allowed because the string is passed to the RegExp constructor, but the syntax is subtly different. This caused one regexp to be invalid and some others to not match correctly.

This converts them to normal JS regex syntax, which seems to work correctly for all of them. It also removes the /g modifier from the single match-or-no-match checks where it's not needed.

This might also fix #9.