### PR TITLE
Check for password length between 12-16 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,11 @@ class Beelzebub {
       infuriationLevel: InfuriationLevel.Low,
     },
     {
+      passwordIsInvalid: password => ( password.length < 12 || password.length > 16),
+      message: 'Password must be 12-16 characters long',
+      infuriationLevel: InfuriationLevel.Low,
+    },
+    {
       passwordIsInvalid: password => password.match(/\d+/) === null,
       message: 'Password must contain at least 1 number',
       infuriationLevel: InfuriationLevel.Low,


### PR DESCRIPTION
Added a Low infuriation level check to ensure a password is between 12 and 16 characters long.